### PR TITLE
Optimize Spherical Mirror Cubemap Updates

### DIFF
--- a/RigidBodyLab/RigidBodyLab/include/physics/CollisionManager.h
+++ b/RigidBodyLab/RigidBodyLab/include/physics/CollisionManager.h
@@ -85,7 +85,7 @@ namespace Physics {
 
     public:
         CollisionManager()
-            : m_friction(0.85f), m_objectRestitution(0.7f), m_groundRestitution(0.6f),
+            : m_friction(10.f), m_objectRestitution(0.7f), m_groundRestitution(0.6f),
             m_iterationLimit(3), m_penetrationTolerance(0.0005f), m_closingSpeedTolerance(0.0005f) {}
 
         void CheckCollision(Core::Object* obj1, Core::Object* obj2);

--- a/RigidBodyLab/RigidBodyLab/include/rendering/Mesh.h
+++ b/RigidBodyLab/RigidBodyLab/include/rendering/Mesh.h
@@ -74,7 +74,7 @@ namespace Rendering {
         GLuint VBO;
         GLuint IBO;
         
-        BoundingBoxInfo m_boundingBoxes;//be default scl=(1,1,1), center={0,0,0}
+        BoundingBoxInfo m_boundingBox;//be default scl=(1,1,1), center={0,0,0}
 
         Mat4 GetBoundingBoxMat()const;
         /*  Mesh function(s) */

--- a/RigidBodyLab/RigidBodyLab/include/rendering/Renderer.h
+++ b/RigidBodyLab/RigidBodyLab/include/rendering/Renderer.h
@@ -49,6 +49,7 @@ namespace Rendering {
 		std::unique_ptr<GLFWwindow, void(*)(GLFWwindow*)> m_window;// Pointer to the window
 		std::vector<int> m_guiToObjectIndexMap;
 
+		int m_sphereMirrorCubeMapFrameCounter;
 		float m_sphereRefIndex;
 		float m_fps;                  // Frame rate
 		RefType m_sphereRef;          // Current reflection/refraction type for the objects
@@ -113,14 +114,7 @@ namespace Rendering {
 
 		void UpdateLightPosViewFrame(Scene& scene);
 		// Function to update the mapping when objects are added/removed
-		void UpdateGuiToObjectIndexMap(const Core::Scene& scene) {
-			m_guiToObjectIndexMap.clear();
-			for (size_t i = 0; i < scene.m_objects.size(); ++i) {
-				if (scene.m_objects[i]->GetCollider()->GetCollisionEnabled() == true) {
-					m_guiToObjectIndexMap.push_back(i);
-				}
-			}
-		}
+		void UpdateGuiToObjectIndexMap(const Core::Scene& scene);
 
 		void RenderSkybox(const Mat4& viewMat);
 		void RenderObj(const Core::Object& obj);
@@ -146,6 +140,8 @@ namespace Rendering {
 		void SetUpSphereUniformLocations(GLuint prog); 
 		void SetUpVertexData(Mesh& mesh);
 		void SetUpShaders();
+
+		bool ShouldUpdateSphereCubemap(float speedSqrd);
 		// GLFW's window handling doesn't directly support smart pointers since the GLFW API is a C API that expects raw pointers. 
 		// therefore, provided a custom deleter for the std::unique_ptr to properly handle GLFW window destruction.
 		static void WindowDeleter(GLFWwindow* window);

--- a/RigidBodyLab/RigidBodyLab/src/rendering/Mesh.cpp
+++ b/RigidBodyLab/RigidBodyLab/src/rendering/Mesh.cpp
@@ -15,7 +15,7 @@ void ComputeNormals(Mesh& mesh);
 void ComputeUVs(Mesh& mesh);
 
 Mat4 Rendering::Mesh::GetBoundingBoxMat() const {
-    return Scale(m_boundingBoxes.extents) * Translate(-m_boundingBoxes.center);
+    return Scale(m_boundingBox.extents) * Translate(-m_boundingBox.center);
 }
 
 /******************************************************************************/
@@ -522,8 +522,8 @@ Mesh Rendering::Mesh::LoadOBJMesh(char* filename)
     ComputeUVs(mesh);
 
     //extents of 2 by default (e.g., x=-1 <--> x=1)
-    mesh.m_boundingBoxes.center = (minPoint + maxPoint) * 0.5f;// (=0.5 * 0.5)
-    mesh.m_boundingBoxes.extents = 1.f / (maxPoint - minPoint);
+    mesh.m_boundingBox.center = (minPoint + maxPoint) * 0.5f;// (=0.5 * 0.5)
+    mesh.m_boundingBox.extents = 1.f / (maxPoint - minPoint);
     
     return mesh;
 }
@@ -674,7 +674,7 @@ void ComputeUVs(Mesh& mesh)
 }
 
 Rendering::Mesh::Mesh()
-    : numVertices(0), numTris(0), numIndices(0), VAO{}, VBO{}, IBO{}, m_boundingBoxes{}
+    : numVertices(0), numTris(0), numIndices(0), VAO{}, VBO{}, IBO{}, m_boundingBox{}
 {
     vertexBuffer.clear();
     indexBuffer.clear();

--- a/RigidBodyLab/RigidBodyLab/src/rendering/Renderer.cpp
+++ b/RigidBodyLab/RigidBodyLab/src/rendering/Renderer.cpp
@@ -158,6 +158,21 @@ void Renderer::SetUpShaders() {
     SetUpMainUniformLocations(m_shaders[TO_INT(ProgType::MAIN_PROG)].GetProgramID());
 }
 
+bool Rendering::Renderer::ShouldUpdateSphereCubemap(float speedSqrd) {
+    constexpr float MIN_SPEED_SQRD = 0.001f;
+    if (speedSqrd <= MIN_SPEED_SQRD) {
+        return false;
+    }
+
+    constexpr int UPDATE_INTERVAL = 50;
+    m_sphereMirrorCubeMapFrameCounter++;
+    if (m_sphereMirrorCubeMapFrameCounter >= UPDATE_INTERVAL) {
+        m_sphereMirrorCubeMapFrameCounter = 0;
+        return true;
+    }
+    return false;
+}
+
 /******************************************************************************/
 /*!
 \fn     void SendLightProperties()
@@ -209,7 +224,7 @@ void Renderer::ComputeMainCamObjMVMats(const Core::Scene& scene)
     }
 }
 
-void Rendering::Renderer::ComputePlanarMirrorCamObjMVMats(const Core::Scene& scene)
+void Renderer::ComputePlanarMirrorCamObjMVMats(const Core::Scene& scene)
 {
     const size_t objSize = scene.m_objects.size();
     for (int i = 0; i < objSize; ++i)
@@ -220,7 +235,7 @@ void Rendering::Renderer::ComputePlanarMirrorCamObjMVMats(const Core::Scene& sce
     }
 }
 
-void Rendering::Renderer::ComputeSphericalMirrorCamObjMVMats(int faceIdx,const Core::Scene& scene)
+void Renderer::ComputeSphericalMirrorCamObjMVMats(int faceIdx,const Core::Scene& scene)
 {
     const size_t objSize = scene.m_objects.size();
     for (int i = 0; i < objSize; ++i)
@@ -272,11 +287,11 @@ void Renderer::ComputeMirrorCamMats(const Core::Scene& scene)
 	// Thresholds for movement
 	static constexpr float POSITION_THRESHOLD = 0.01f;
 
-	static Core::Transform previousMirrorTransform = scene.m_mirror->GetPosition();
-	const Core::Transform& currentMirrorTransform = scene.m_mirror->GetPosition();
+	static Math::Vector3 previousMirrorPos = scene.m_mirror->GetPosition();
+	const Math::Vector3& currentMirrorPos = previousMirrorPos;
 
-    Math::Vector3 positionDelta = currentMirrorTransform.m_position - previousMirrorTransform.m_position;
-	previousMirrorTransform = currentMirrorTransform;
+    Math::Vector3 positionDelta = currentMirrorPos - previousMirrorPos;
+	previousMirrorPos = currentMirrorPos;
 	
     if (positionDelta.Length() > POSITION_THRESHOLD) {
 		mirrorCam.moved = true;
@@ -294,8 +309,9 @@ void Renderer::ComputeMirrorCamMats(const Core::Scene& scene)
             m_mirrorVisible = false;
             return;
         }
-        else
+        else {
             m_mirrorVisible = true;
+        }
 
         /*  In mirror frame, mirror camera position is defined as (x, y, -z) in which (x, y, z) is the
             user camera position in mirror frame.
@@ -310,9 +326,8 @@ void Renderer::ComputeMirrorCamMats(const Core::Scene& scene)
         // Setting mirror camera's position and look-at point
         mirrorCam.pos = Vec3(mirrorMat * Vec4(mirrorCamMirrorFrame, 1.0));
         mirrorCam.upVec = Normalize(Vec3(mirrorMat * Vec4(0, 1, 0, 0)));
-        Vec3 mirrorCenter = scene.m_mirror->GetMesh()->m_boundingBoxes.center;
+        Vec3 mirrorCenter = scene.m_mirror->GetMesh()->m_boundingBox.center;
         mirrorCam.lookAt = Vec3(mirrorMat* Vec4{ mirrorCenter,1.f });
-
 
         m_mirrorCamViewMat = LookAt(mirrorCam.pos, mirrorCam.lookAt, mirrorCam.upVec);
 
@@ -412,7 +427,7 @@ void Renderer::ComputeSphereCamMats(const Core::Scene& scene)
         The bottom and top faces are -y and +y.
     */
     // Directions for the cubemap faces
-    Vec3 lookAt[TO_INT(CubeFaceID::NUM_FACES)] = {
+    const static Vec3 lookAt[TO_INT(CubeFaceID::NUM_FACES)] = {
         BASIS[0], // RIGHT
         -BASIS[0], // LEFT
         BASIS[1], // TOP
@@ -427,7 +442,7 @@ void Renderer::ComputeSphereCamMats(const Core::Scene& scene)
         upVec is pointing backward.
     */
     // Up vectors for the cubemap faces
-    Vec3 upVec[TO_INT(CubeFaceID::NUM_FACES)] = {
+    const static Vec3 upVec[TO_INT(CubeFaceID::NUM_FACES)] = {
         -BASIS[1], // RIGHT flipped
         -BASIS[1], // LEFT flipped
         BASIS[2],  // TOP flipped
@@ -435,7 +450,6 @@ void Renderer::ComputeSphereCamMats(const Core::Scene& scene)
         -BASIS[1], // BACK flipped
         -BASIS[1]  // FRONT flipped
     };
-
 
     for (int f = 0; f < TO_INT(CubeFaceID::NUM_FACES); ++f)
     {
@@ -450,15 +464,15 @@ void Renderer::ComputeSphereCamMats(const Core::Scene& scene)
         The near plane distance is 0.01f. The far plane distance is equal to mainCam's farPlane.
     */
     // Compute the projection matrix for the sphere camera
-    float fov = PI / 2.f; // 90 degrees in radians
-    float aspectRatio = 1.0f;
-    float nearPlane = 0.01f; // near plane is 0.01, and far plane is the same as the main camera's far plane
+    constexpr float fov = PI / 2.f; // 90 degrees in radians
+    constexpr float aspectRatio = 1.f;
+    constexpr float nearPlane = 0.01f; // near plane is 0.01, and far plane is the same as the main camera's far plane
     m_sphereCamProjMat = Perspective(fov, aspectRatio, nearPlane, mainCam.farPlane);
 }
 
 void Rendering::Renderer::RenderGui(Scene& scene, float fps) {
     ImGui::SetNextWindowPos(ImVec2(Camera::DISPLAY_SIZE, 0));
-    ImGui::SetNextWindowSize(ImVec2(Camera::GUI_WIDTH, Camera::GUI_WIDTH * 2.f));
+    ImGui::SetNextWindowSize(ImVec2(Camera::GUI_WIDTH, Camera::GUI_WIDTH * 3.f));
 
     // displaying FPS
     ImGui::Text("Frame Rate: %.1f", fps);
@@ -778,6 +792,7 @@ Rendering::Renderer::Renderer()
     , m_sphereRef(RefType::REFLECTION_ONLY)
     , m_parallaxMappingOn(true), m_sphereRefIndex{ 1.33f }//water by default
     , m_shouldUpdateCubeMapForSphere{ true }
+    , m_sphereMirrorCubeMapFrameCounter{}
 
     , m_mainCamViewMat{}
     , m_mainCamProjMat{}
@@ -911,6 +926,17 @@ void Rendering::Renderer::UpdateLightPosViewFrame(Core::Scene& scene)
     }
 }
 
+// Function to update the mapping when objects are added/removed
+
+void Rendering::Renderer::UpdateGuiToObjectIndexMap(const Core::Scene& scene) {
+    m_guiToObjectIndexMap.clear();
+    for (size_t i = 0; i < scene.m_objects.size(); ++i) {
+        if (scene.m_objects[i]->GetCollider()->GetCollisionEnabled() == true) {
+            m_guiToObjectIndexMap.push_back(i);
+        }
+    }
+}
+
 // GLFW's window handling doesn't directly support smart pointers since the GLFW API is a C API that expects raw pointers. 
 // therefore, provided a custom deleter for the std::unique_ptr to properly handle GLFW window destruction.
 void Renderer::WindowDeleter(GLFWwindow* window) {
@@ -970,7 +996,7 @@ void Renderer::RenderObj(const Core::Object& obj)
 void Renderer::RenderSphere(const Core::Scene& scene)
 {
     if (scene.m_sphere == nullptr) {
-        return; // No sphere to render
+        return; // no sphere to render
     }
 
     m_shaders[TO_INT(ProgType::SPHERE_PROG)].Use();
@@ -988,7 +1014,7 @@ void Renderer::RenderSphere(const Core::Scene& scene)
 
     // Compute and send the model-view matrix for the sphere
     Mat4 sphereMV = m_mainCamViewMat * scene.m_sphere->GetModelMatrixGLM();
-    Mat4 sphereNMV = Transpose(Inverse(sphereMV)); // or however you calculate the normal model-view matrix
+    Mat4 sphereNMV = Transpose(Inverse(sphereMV));
     SendMVMat(sphereMV, sphereNMV, m_sphereMVMatLoc, m_sphereNMVMatLoc);
 
     // Send the projection matrix
@@ -996,11 +1022,6 @@ void Renderer::RenderSphere(const Core::Scene& scene)
 
     // Finally, render the sphere
     RenderObj(*scene.m_sphere);
-
-    //SendMVMat(m_mainCamMVMat[TO_INT(ObjID::SPHERE)], m_mainCamNormalMVMat[TO_INT(ObjID::SPHERE)], m_sphereMVMatLoc, m_sphereNMVMatLoc);
-    //SendProjMat(m_mainCamProjMat, m_sphereProjMatLoc);
-
-    //RenderObj(scene.GetObject(TO_INT(ObjID::SPHERE)));
 }
 
 
@@ -1376,10 +1397,12 @@ void Renderer::Render(Core::Scene& scene, float fps)
 
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
+
     /*  The texture used for sphere reflection/refraction is view-independent,
         so it only needs to be rendered once in the beginning
     */
-    if (m_shouldUpdateCubeMapForSphere)
+    if (m_shouldUpdateCubeMapForSphere 
+        || ShouldUpdateSphereCubemap(scene.m_sphere->GetRigidBody()->GetLinearVelocity().LengthSquared())==true)
     {
         ComputeSphereCamMats(scene);
         ResourceManager& resourceManager = ResourceManager::GetInstance();

--- a/RigidBodyLab/RigidBodyLab/src/rendering/ResourceManager.cpp
+++ b/RigidBodyLab/RigidBodyLab/src/rendering/ResourceManager.cpp
@@ -16,21 +16,14 @@ ResourceManager::ResourceManager()
     m_meshes[TO_INT(MeshID::SPHERE)] = std::make_unique<Mesh>(Mesh::CreateSphere(16, 16));
     m_meshes[TO_INT(MeshID::VASE)] = std::make_unique<Mesh>(Mesh::LoadOBJMesh("../RigidBodyLab/models/vase.obj"));
     m_meshes[TO_INT(MeshID::TEAPOT)] = std::make_unique<Mesh>(Mesh::LoadOBJMesh("../RigidBodyLab/models/teapot.obj"));
+    // adjust the teapot's bounding box. The original model has an elongated shape (oval), so we scale its x-dimension to achieve a more proportionate and visually pleasing appearance.
     m_meshes[TO_INT(MeshID::DIAMOND)] = std::make_unique<Mesh>(Mesh::LoadOBJMesh("../RigidBodyLab/models/diamond.obj"));
     m_meshes[TO_INT(MeshID::DODECAHEDRON)] = std::make_unique<Mesh>(Mesh::LoadOBJMesh("../RigidBodyLab/models/dodecahedron.obj"));
     m_meshes[TO_INT(MeshID::GOURD)] = std::make_unique<Mesh>(Mesh::LoadOBJMesh("../RigidBodyLab/models/gourd.obj"));
 
-    stbi_set_flip_vertically_on_load(true);
+    m_meshes[TO_INT(MeshID::TEAPOT)]->m_boundingBox.extents.x *= 2.f; 
 
-    //SetUpObjTextures();
-    ///*  Set up bump map and normal map for the base object */
-    //SetUpBaseBumpNormalTextures();
-    ///*  Set up skybox texture for background rendering */
-    //SetUpSkyBoxTexture();
-    ///*  Set up texture object for mirror reflection. This texture object hasn't stored any data yet.
-    //    We will render the reflected data for this texture on the fly.
-    //*/
-    //SetUpMirrorTexture();
+    stbi_set_flip_vertically_on_load(true);
 }
 
 ResourceManager& ResourceManager::GetInstance()
@@ -139,12 +132,6 @@ void Rendering::ResourceManager::SetUpBaseBumpNormalTextures()
     int imgWidth, imgHeight, numComponents;
 
     /*  Load bump image */
-    //bumpImgData = stbi_load(bumpTexFile, &imgWidth, &imgHeight, &numComponents,0);
-    //if (!bumpImgData)
-    //{
-    //    std::cerr << "Reading " << bumpTexFile << " failed.\n";
-    //    exit(1);
-    //}
     if (ReadImageFile(bumpTexFile, &bumpImgData, &imgWidth, &imgHeight, &numComponents) == 0)
     {
         std::cerr << "Reading " << bumpTexFile << " failed.\n";


### PR DESCRIPTION
Introduce 'ShouldUpdateSphereCubemap' in Renderer to optimize cubemap updates for the spherical mirror. Updates now occur every 50 frames if the object is in motion, reducing computational load and improving performance while maintaining acceptable visual reflections.